### PR TITLE
Add terminal UI renderer for game states

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ The goal of the board game Splendor is to reach 15 points by either taking chips
    python splendor_fastest_win.py
    ```
 
+### Visualize a solution
+Render the sequence of states for a solved game directly in the terminal:
+
+```bash
+python -m src.ui 10 --use-heuristic
+```
+
+The command above prints every step needed to reach 10 points, including gems on hand,
+bonuses from purchased cards, and the cards themselves.
+
 ### How it works
 The tool uses breadth-first search to greedily check all possible move sequences. Optionally you can use a heuristic that limits search space of BFS by using only the most promising game states.
 

--- a/src/ui.py
+++ b/src/ui.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import argparse
+from textwrap import indent
+
+from src.cardparser import get_deck
+from src.color import Color
+from src.solver import State
+
+COLOR_LABELS = {
+    Color.WHITE: 'White',
+    Color.BLUE: 'Blue',
+    Color.GREEN: 'Green',
+    Color.RED: 'Red',
+    Color.BLACK: 'Black',
+}
+
+deck = get_deck()
+
+
+def format_gems(title: str, gems: tuple[int, ...]) -> str:
+    color_pairs = zip(COLOR_LABELS.values(), gems)
+    parts = ', '.join(f'{name}: {amount}' for name, amount in color_pairs)
+    return f"{title}: {parts}"
+
+
+def format_cards(cards: tuple[int, ...]) -> str:
+    if not cards:
+        return 'Cards: none yet'
+    card_ids = ', '.join(deck[i].str_id for i in cards)
+    return f'Cards: {card_ids}'
+
+
+def describe_state(step: int, state: State) -> str:
+    lines = [
+        f'Step {step}',
+        f'Points: {state.pts}',
+        format_gems('Held gems', state.gems),
+        format_gems('Bonus gems', state.bonus),
+        format_cards(state.cards),
+        f'Saved cost (discounted by bonuses): {state.saved}',
+    ]
+    return '\n'.join(lines)
+
+
+def render_solution(goal_pts: int, use_heuristic: bool) -> str:
+    solution = State.newgame().solve(goal_pts, use_heuristic=use_heuristic)
+    rendered = [describe_state(step, state) for step, state in enumerate(solution)]
+    return '\n\n'.join(rendered)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description='Render a human-friendly view of a solved Splendor game.',
+    )
+    parser.add_argument(
+        'goal',
+        nargs='?',
+        type=int,
+        default=15,
+        help='Target number of points to reach (default: 15).',
+    )
+    parser.add_argument(
+        '-u',
+        '--use-heuristic',
+        action='store_true',
+        help='Use heuristic pruning when searching for the solution.',
+    )
+    args = parser.parse_args()
+
+    solution_text = render_solution(args.goal, args.use_heuristic)
+    header = f"Solution to reach {args.goal} points:\n"
+    print(header + indent(solution_text, '  '))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,23 @@
+from src.solver import State
+from src.ui import describe_state, format_cards, format_gems
+
+
+def test_format_gems_human_readable():
+    text = format_gems('Held gems', (1, 2, 3, 4, 5))
+    assert 'Held gems' in text
+    assert 'White: 1' in text
+    assert 'Black: 5' in text
+
+
+def test_format_cards_includes_card_ids():
+    text = format_cards((0,))
+    assert text.startswith('Cards: ')
+    assert len(text.split(',')) >= 1
+
+
+def test_describe_state_summarizes_numbers():
+    state = State(cards=(0,), bonus=(1, 0, 0, 0, 0), gems=(2, 3, 4, 5, 6), pts=2, saved=1)
+    summary = describe_state(3, state)
+    assert 'Step 3' in summary
+    assert 'Points: 2' in summary
+    assert 'Saved cost (discounted by bonuses): 1' in summary


### PR DESCRIPTION
## Summary
- add a terminal UI module to render solved Splendor game states with readable gem and card info
- document how to visualize solutions from the command line
- cover the new formatter utilities with unit tests

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236174a0188326a6895ff94fd7010a)