### PR TITLE
Add configuration output to solver

### DIFF
--- a/src/solver.py
+++ b/src/solver.py
@@ -408,6 +408,20 @@ class State:
         Returns:
             List of states representing the solution path
         """
+        # Print configuration
+        if verbose:
+            print('='*60)
+            print('SPEEDRUN MODE SOLVER')
+            print('='*60)
+            print(f'Target Points: {goal_pts}')
+            print(f'Heuristic: {heuristic_name if use_heuristic else "None (pure BFS)"}')
+            if use_heuristic:
+                print(f'Beam Width: {beam_width:,}')
+            print(f'Gem Pool: Infinite')
+            print(f'Card Visibility: All 90 cards')
+            print('='*60)
+            print()
+
         queue: list[State] = [self]
         trail: dict[State, State | None] = {self: None}
 
@@ -742,6 +756,21 @@ class MultiPlayerState:
         verbose: bool = True,
     ) -> list['MultiPlayerState']:
         """Solve multi-player game using BFS with heuristic search."""
+        # Print configuration
+        if verbose:
+            print('='*60)
+            print('REALISTIC MODE SOLVER')
+            print('='*60)
+            print(f'Target Points: {self.config.target_points}')
+            print(f'Number of Players: {self.config.num_players}')
+            print(f'Gems per Color: {self.config.gems_per_color}')
+            print(f'Heuristic: {heuristic_name}')
+            print(f'Beam Width: {beam_width:,}')
+            print(f'Card Visibility: 12 cards (4 per tier)')
+            print(f'Market Shuffled: {"Yes" if self.market.tier1_deck != self.market.tier1_deck[:1] else "No (deterministic)"}')
+            print('='*60)
+            print()
+
         queue: list[MultiPlayerState] = [self]
         trail: dict[MultiPlayerState, MultiPlayerState | None] = {self: None}
 


### PR DESCRIPTION
## Summary

Add detailed configuration output at the start of solver execution to improve visibility into what parameters are being used during the solve process.

## Changes

### Speedrun Mode Solver
When solving in speedrun mode, now displays:
- Target points
- Heuristic name (or "None (pure BFS)" if disabled)
- Beam width (when using heuristic)
- Gem pool configuration (Infinite)
- Card visibility (All 90 cards)

### Realistic Mode Solver
When solving in realistic mode, now displays:
- Target points
- Number of players
- Gems per color
- Heuristic name
- Beam width
- Card visibility (12 cards, 4 per tier)
- Market shuffle status

## Example Output

**Speedrun Mode:**
```
============================================================
SPEEDRUN MODE SOLVER
============================================================
Target Points: 10
Heuristic: aggressive
Beam Width: 100,000
Gem Pool: Infinite
Card Visibility: All 90 cards
============================================================
```

**Realistic Mode:**
```
============================================================
REALISTIC MODE SOLVER
============================================================
Target Points: 6
Number of Players: 2
Gems per Color: 4
Heuristic: competitive
Beam Width: 5,000
Card Visibility: 12 cards (4 per tier)
Market Shuffled: Yes
============================================================
```

## Benefits

- Users can clearly see what solver configuration is being used
- Easier to debug and compare different runs
- Improved UX for understanding solver behavior
- Configuration is only shown when `verbose=True` (respects quiet mode)

## Testing

Tested with:
- ✅ Speedrun mode with balanced heuristic
- ✅ Speedrun mode with aggressive heuristic
- ✅ Realistic mode with competitive heuristic
- ✅ Quiet mode (no config output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)